### PR TITLE
standardize ebnf

### DIFF
--- a/.data/sigmac.def
+++ b/.data/sigmac.def
@@ -1,4 +1,4 @@
-<program>   := <function> ;
-<function>  := "int" <id> "(" ")" "{" <statement> "}" ;
-<statement> := "return" <expr> ";" ;
-<expr>      := <int> ;
+<program>   ::= <function>
+<function>  ::= "int" <id> "(" ")" "{" <statement> "}"
+<statement> ::= "return" <expr> ";"
+<expr>      ::= <int>

--- a/src/codex.c
+++ b/src/codex.c
@@ -30,8 +30,9 @@ static bool codex_load_definition(void);
 static void codex_dispose(void);
 
 static parser parser_new(void);
-static bool parser_load_ruleset(void);
 static bool parser_add_source(string);
+static bool parser_clear_sources(void);
+static bool parser_load_ruleset(void);
 //	DEFINITIONS
 //	========================= Codex =========================
 
@@ -114,18 +115,43 @@ static bool parser_load_ruleset()
 	pIndexer->tokenize(CODEX->definition, &pToken);
 
 	// #if DEBUG
-	char *word = NULL;
-	token ptr = pToken;
-
-	printf("\n");
-	while (ptr)
-	{
-		Token.word(ptr, &word);
-		printf("%s\n", word);
-
-		ptr = ptr->next;
-	}
+	// string word = NULL;
+	// token ptr = pToken;
+	// printf("\n");
+	// while (ptr)
+	// {
+	// 	Token.word(ptr, &word);
+	// 	if (word == NULL)
+	// 	{
+	// 		break;
+	// 	}
+	// 	printf("%s%s", *word != '\0' ? word : "", *word == '\n' ? "" : "\n");
+	// 	ptr = ptr->next;
+	// }
+	// String.free(word);
 	// #endif
+
+	/*
+		The roadblock here is "what does a RuleSet" even look like and how do the component Rules even
+		function? Does the concept of a Rule even make sense? There appears to be a school of thought
+		that directs the EBNF to 'prioritize' productions from highest to lowest. In a way, this seems
+		counter-intuitive as all source is built on LETTERS, DIGITS, & SYMBOLS.
+
+		So my question, intuitively, is: what am I looking at?
+		 -	Letters?
+		 -	Digits?
+		 -	Symbols?
+		 -	Alphanumerics?
+
+		Once I know what I am looking at from the smallest component, it seems logical to progress
+		from the bottom up. That said, I am (at the moment) speaking with the understanding that I
+		don't know what I don't know.
+
+		It doesn't seem unreasonable to approach parsing from the smallest components and determine
+		(from how we analyze what we're looking at) how a Rule is composed and how it should
+		function. The Rule should result in an functional analyzer composed from a production. A RuleSet
+		is a collection of Rules.
+	*/
 
 	return retOk;
 }
@@ -160,6 +186,20 @@ static bool parser_add_source(string srcPath)
 
 	return retOk && SOURCES != NULL;
 }
+static bool parser_clear_sources(void)
+{
+	bool retOk = SOURCES != NULL;
+	if (retOk)
+	{
+		//	TODO: `for_each` function
+		if (!(retOk = Document.dispose(SOURCES)))
+		{
+			printf("ERROR: fault disposing document %s\n", SOURCES->source);
+		}
+	}
+
+	return retOk;
+}
 static bool parser_load_sources(void)
 {
 	bool retOk = true;
@@ -172,21 +212,19 @@ static bool parser_load_sources(void)
 	pIndexer->tokenize(SOURCES, &pToken);
 
 	// #if DEBUG
-	string word = NULL;
-	token ptr = pToken;
-	while (ptr)
-	{
-		Token.word(ptr, &word);
-		if (word == NULL)
-		{
-			break;
-		}
-
-		printf("%s%s", *word != '\0' ? word : "", *word == '\n' ? "" : "\n");
-
-		ptr = ptr->next;
-	}
-	String.free(word);
+	// string word = NULL;
+	// token ptr = pToken;
+	// while (ptr)
+	// {
+	// 	Token.word(ptr, &word);
+	// 	if (word == NULL)
+	// 	{
+	// 		break;
+	// 	}
+	// 	printf("%s%s", *word != '\0' ? word : "", *word == '\n' ? "" : "\n");
+	// 	ptr = ptr->next;
+	// }
+	// String.free(word);
 	// #endif
 
 	return retOk;
@@ -244,5 +282,7 @@ const struct SC_Codex Codex = {
 };
 const struct SC_Parser Parser = {
 	.add_source = &parser_add_source,
+	.clear_sources = &parser_clear_sources,
 	.load_sources = &parser_load_sources,
+
 };

--- a/src/codex.h
+++ b/src/codex.h
@@ -52,6 +52,7 @@ extern const struct SC_Codex
 extern const struct SC_Parser
 {
 	bool (*add_source)(string);
+	bool (*clear_sources)(void);
 	bool (*load_sources)(void);
 } Parser;
 

--- a/src/ebnf_indexer.h
+++ b/src/ebnf_indexer.h
@@ -4,7 +4,7 @@
 #include "open/types.h"
 #include "indexer.h"
 
-const string ASSIGNMENT = ":=";
+const string ASSIGNMENT = "::=";
 
 bool index_ebnf(document pDoc, token *pTknHead)
 {
@@ -20,13 +20,13 @@ bool index_ebnf(document pDoc, token *pTknHead)
 
     while (pos < srcLen)
     {
-        if (is_noise(*ndx))
+        if (is(*ndx, SPACE))
         {
             ++ndx;
             ++pos;
             continue;
         }
-        else if (is(*ndx, ENDLINE))
+        else if (is(*ndx, NEWLINE))
         {
             ++line;
             wrdEnd = ndx;
@@ -35,7 +35,7 @@ bool index_ebnf(document pDoc, token *pTknHead)
         else
         {
             //  pass NULL to delims param to default SPACE word delimeter
-            wrdEnd = get_word(ndx, NULL, srcLen - pos);
+            wrdEnd = get_word(ndx, " \n\0", srcLen - pos);
             length = wrdEnd - ndx + 1;
         }
         //    	printf("[%d] start: %ld len: %ld    [w:%c-%c]\n", line, start, length, ptr[0], pWrd[0]);

--- a/src/indexer.h
+++ b/src/indexer.h
@@ -27,6 +27,7 @@ typedef struct io_indexer *indexer;
 extern const struct Document_T
 {
     bool (*load)(stream, document *);
+    bool (*dispose)(document);
 } Document;
 
 extern const struct IO_Indexer
@@ -40,13 +41,12 @@ extern const struct IO_Indexer
 //  generic indexer functions
 static const char SPACE = ' ';
 static const char NEWLINE = '\n';
-static const char ENDLINE = ';';
 
 static bool is(char c, char cmp)
 {
     return c == cmp;
 }
-static bool any(char c, string cmps)
+static bool is_any(char c, string cmps)
 {
     //  to use this properly, terminate series with '\0'
     bool retAny = false;
@@ -80,7 +80,7 @@ static char *get_word(char *pChar, string delims, size_t strLen)
 
     while (ndx - pChar < strLen)
     {
-        if (any(*ndx, delims))
+        if (is_any(*ndx, delims))
         {
             end = ndx - 1;
 

--- a/src/source_indexer.h
+++ b/src/source_indexer.h
@@ -4,6 +4,7 @@
 #include "open/types.h"
 #include "indexer.h"
 
+const char ENDSTMT = ';';
 const char OPN_BRACE = '{'; // 2:'{'!'}'
 const char CLS_BRACE = '}'; // ...
 const char OPN_BRACK = '['; // 2:'['!']'
@@ -94,7 +95,7 @@ static bool is_newline(char c)
 }
 static bool is_symbol(char c)
 {
-    return is_paired(c) || is(c, ENDLINE);
+    return is_paired(c) || is(c, ENDSTMT);
 }
 static bool is_paired(char c)
 {

--- a/src/test/codex_tests.c
+++ b/src/test/codex_tests.c
@@ -6,6 +6,8 @@
 
 //  TEST CASE prototypes
 void _load_codex(void);
+void _add_source(void);
+void _load_source(void);
 
 //  utility prototypes
 void _output_codex_info(codex);
@@ -19,6 +21,8 @@ int main(int argc, string *argv)
     BEGIN_SET(SigC.Codex, true)
     {
         TEST(_load_codex);
+        TEST(_add_source);
+        TEST(_load_source);
     }
     END_SET(SigC.Codex)
 
@@ -34,4 +38,24 @@ void _load_codex()
     assert(Codex.init(cwd, &cdx));
 
     Codex.dispose();
+}
+void _add_source()
+{
+    writefln("dir: %s", cwd->path);
+    string srcPath = "./.targets/001/main.C";
+
+    // assert(Path.exists(srcPath));
+    assert(Parser.add_source(srcPath));
+    assert(Parser.clear_sources());
+}
+void _load_source()
+{
+    write_header("sigc::Parser.load_source: load source file");
+
+    string srcPath = "./.targets/001/main.C";
+
+    Parser.add_source(srcPath);
+    assert(Parser.load_sources());
+
+    Parser.clear_sources();
 }


### PR DESCRIPTION
removed ';' as EOS token
modified `indexer` to tokenize EOL ('\n')